### PR TITLE
Updating the appVersion for Firely  Auth and Firely Server helm charts

### DIFF
--- a/charts/firely-auth/Chart.yaml
+++ b/charts/firely-auth/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/firely-auth/Chart.yaml
+++ b/charts/firely-auth/Chart.yaml
@@ -28,4 +28,4 @@ version: 0.6.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.1.1"
+appVersion: "4.3.0"

--- a/charts/firely-auth/values.yaml
+++ b/charts/firely-auth/values.yaml
@@ -55,7 +55,7 @@ replicaCount: 1
 image:
   repository: firely/auth
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # Overrides the image tag. If left blank, it will fallback to .Chart.AppVersion via the Helm default function.
   tag: ""
 
 imagePullSecrets: []

--- a/charts/firely-auth/values.yaml
+++ b/charts/firely-auth/values.yaml
@@ -56,7 +56,7 @@ image:
   repository: firely/auth
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "4.1.1"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/firely-server/Chart.yaml
+++ b/charts/firely-server/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "5.11.0"
+appVersion: "6.1.0"
 version: "0.19.0"
 kubeVersion: ">= 1.19"
 name: firely-server

--- a/charts/firely-server/Chart.yaml
+++ b/charts/firely-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "6.1.0"
-version: "0.19.0"
+appVersion: "6.2.0"
+version: "0.20.0"
 kubeVersion: ">= 1.19"
 name: firely-server
 description: Firely Server is an enterprise-grade FHIR server meant for production environments large and small alike. 

--- a/charts/firely-server/templates/deployment.yaml
+++ b/charts/firely-server/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/firely-server/values.yaml
+++ b/charts/firely-server/values.yaml
@@ -6,7 +6,8 @@ replicaCount: 1
 
 image:
   repository: firely/server
-  tag: 5.9.1
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
   pullPolicy: IfNotPresent
 
 # Add you annotations to the deployment here

--- a/charts/firely-server/values.yaml
+++ b/charts/firely-server/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: firely/server
-  # Overrides the image tag whose default is the chart appVersion.
+  # Overrides the image tag. If left blank, it will fallback to .Chart.AppVersion via the Helm default function.
   tag: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Use the appVersion for the image tag by default

## Description
Change the logic so as to use the appVersion as the image tag by default

## Related issues
Closes DEVOPS-479.

## Testing
Using minikube to deploy and check successful deployment with the expected image tag.

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes