### PR TITLE
Update Helm Chart index.yaml to firely-server-0.20.1

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,6 +1,150 @@
 apiVersion: v1
 entries:
+  firely-auth:
+  - apiVersion: v2
+    appVersion: 4.1.1
+    created: "2024-12-19T13:56:40.637081109Z"
+    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
+    digest: c270fd1ca87bf26fead782835c621d9fc65571fa580b409fe844a4ede865ab53
+    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
+    kubeVersion: '>= 1.19'
+    maintainers:
+    - email: louis@fire.ly
+      name: Louis Latour
+      url: https://fire.ly
+    name: firely-auth
+    type: application
+    urls:
+    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.6.1/firely-auth-0.6.1.tgz
+    version: 0.6.1
+  - apiVersion: v2
+    appVersion: 4.1.1
+    created: "2024-12-19T13:56:40.635878604Z"
+    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
+    digest: 0770b5940e4e5948836d3d9c99f336973e227893adf71e84362ab28436bb1056
+    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
+    kubeVersion: '>= 1.19'
+    maintainers:
+    - email: louis@fire.ly
+      name: Louis Latour
+      url: https://fire.ly
+    name: firely-auth
+    type: application
+    urls:
+    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.6.0/firely-auth-0.6.0.tgz
+    version: 0.6.0
+  - apiVersion: v2
+    appVersion: 3.3.1
+    created: "2024-12-19T13:56:40.631507684Z"
+    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
+    digest: 094a4c91fe2c821bdc242b52134b11c4c717e846d62b43e61dccee50d595a889
+    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
+    kubeVersion: '>= 1.19'
+    maintainers:
+    - email: louis@fire.ly
+      name: Louis Latour
+      url: https://fire.ly
+    name: firely-auth
+    type: application
+    urls:
+    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.5.0/firely-auth-0.5.0.tgz
+    version: 0.5.0
+  - apiVersion: v2
+    appVersion: 3.3.1
+    created: "2024-12-19T13:56:40.630559079Z"
+    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
+    digest: 33fae00b790b14e99af8a55e10c0156dadecdda03b95f592a09cd9dcc1de0286
+    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
+    kubeVersion: '>= 1.19'
+    maintainers:
+    - email: marco@fire.ly
+      name: Marco Visser
+      url: https://fire.ly
+    name: firely-auth
+    type: application
+    urls:
+    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.4.0/firely-auth-0.4.0.tgz
+    version: 0.4.0
+  - apiVersion: v2
+    appVersion: 3.0.0
+    created: "2024-12-19T13:56:40.629781376Z"
+    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
+    digest: 71abfe715c35ed382fec11b2a2428e0ff0004564d444950e441f5cd87f798e15
+    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
+    kubeVersion: '>= 1.19'
+    maintainers:
+    - email: marco@fire.ly
+      name: Marco Visser
+      url: https://fire.ly
+    name: firely-auth
+    type: application
+    urls:
+    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.3.1/firely-auth-0.3.1.tgz
+    version: 0.3.1
+  - apiVersion: v2
+    appVersion: 3.0.0
+    created: "2024-12-19T13:56:40.628258069Z"
+    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
+    digest: 19e607e63dc9038da2ff44a6e4e37dbaa66e48bd0b36499edc1bc91f6abb2a50
+    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
+    kubeVersion: '>= 1.19'
+    maintainers:
+    - email: marco@fire.ly
+      name: Marco Visser
+      url: https://fire.ly
+    name: firely-auth
+    type: application
+    urls:
+    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.3.0/firely-auth-0.3.0.tgz
+    version: 0.3.0
+  - apiVersion: v2
+    appVersion: 3.0.0
+    created: "2024-12-19T13:56:40.627472565Z"
+    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
+    digest: afc099066f698622a887666de74fe96de12a39bc164e73b2e81edbbbfd3d5bd8
+    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
+    kubeVersion: '>= 1.19'
+    maintainers:
+    - email: marco@fire.ly
+      name: Marco Visser
+      url: https://fire.ly
+    name: firely-auth
+    type: application
+    urls:
+    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.2.0/firely-auth-0.2.0.tgz
+    version: 0.2.0
   firely-server:
+  - apiVersion: v2
+    appVersion: 6.1.0
+    created: "2025-09-02T10:12:51.818940776Z"
+    dependencies:
+    - condition: influxdb2.enabled
+      name: influxdb2
+      repository: https://helm.influxdata.com/
+      version: 2.1.2
+    - condition: telegraf.enabled
+      name: telegraf
+      repository: https://helm.influxdata.com/
+      version: 1.8.48
+    - condition: opentelemetry-collector.enabled
+      name: opentelemetry-collector
+      repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+      version: 0.90.1
+    description: Firely Server is an enterprise-grade FHIR server meant for production
+      environments large and small alike.
+    digest: d64b926ca9cfbd463394ac86649b2da6a54188f619094d2d02b87e09fe48156b
+    home: https://fire.ly/products/firely-server/
+    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
+    kubeVersion: '>= 1.19.0-0'
+    maintainers:
+    - email: louis@fire.ly
+      name: Louis Latour
+      url: https://fire.ly
+    name: firely-server
+    type: application
+    urls:
+    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FS%2Fv0.20.1/firely-server-0.20.1.tgz
+    version: 0.20.1
   - apiVersion: v2
     appVersion: 5.11.0
     created: "2025-02-10T10:02:46.749551572Z"
@@ -251,117 +395,4 @@ entries:
     urls:
     - https://github.com/FirelyTeam/Helm.Charts/releases/download/FS%2Fv0.11.0/firely-server-0.11.0.tgz
     version: 0.11.0
-  firely-auth:
-  - apiVersion: v2
-    appVersion: 4.1.1
-    created: "2024-12-19T13:56:40.637081109Z"
-    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
-    digest: c270fd1ca87bf26fead782835c621d9fc65571fa580b409fe844a4ede865ab53
-    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
-    kubeVersion: '>= 1.19'
-    maintainers:
-    - email: louis@fire.ly
-      name: Louis Latour
-      url: https://fire.ly
-    name: firely-auth
-    type: application
-    urls:
-    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.6.1/firely-auth-0.6.1.tgz
-    version: 0.6.1
-  - apiVersion: v2
-    appVersion: 4.1.1
-    created: "2024-12-19T13:56:40.635878604Z"
-    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
-    digest: 0770b5940e4e5948836d3d9c99f336973e227893adf71e84362ab28436bb1056
-    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
-    kubeVersion: '>= 1.19'
-    maintainers:
-    - email: louis@fire.ly
-      name: Louis Latour
-      url: https://fire.ly
-    name: firely-auth
-    type: application
-    urls:
-    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.6.0/firely-auth-0.6.0.tgz
-    version: 0.6.0
-  - apiVersion: v2
-    appVersion: 3.3.1
-    created: "2024-12-19T13:56:40.631507684Z"
-    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
-    digest: 094a4c91fe2c821bdc242b52134b11c4c717e846d62b43e61dccee50d595a889
-    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
-    kubeVersion: '>= 1.19'
-    maintainers:
-    - email: louis@fire.ly
-      name: Louis Latour
-      url: https://fire.ly
-    name: firely-auth
-    type: application
-    urls:
-    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.5.0/firely-auth-0.5.0.tgz
-    version: 0.5.0
-  - apiVersion: v2
-    appVersion: 3.3.1
-    created: "2024-12-19T13:56:40.630559079Z"
-    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
-    digest: 33fae00b790b14e99af8a55e10c0156dadecdda03b95f592a09cd9dcc1de0286
-    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
-    kubeVersion: '>= 1.19'
-    maintainers:
-    - email: marco@fire.ly
-      name: Marco Visser
-      url: https://fire.ly
-    name: firely-auth
-    type: application
-    urls:
-    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.4.0/firely-auth-0.4.0.tgz
-    version: 0.4.0
-  - apiVersion: v2
-    appVersion: 3.0.0
-    created: "2024-12-19T13:56:40.629781376Z"
-    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
-    digest: 71abfe715c35ed382fec11b2a2428e0ff0004564d444950e441f5cd87f798e15
-    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
-    kubeVersion: '>= 1.19'
-    maintainers:
-    - email: marco@fire.ly
-      name: Marco Visser
-      url: https://fire.ly
-    name: firely-auth
-    type: application
-    urls:
-    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.3.1/firely-auth-0.3.1.tgz
-    version: 0.3.1
-  - apiVersion: v2
-    appVersion: 3.0.0
-    created: "2024-12-19T13:56:40.628258069Z"
-    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
-    digest: 19e607e63dc9038da2ff44a6e4e37dbaa66e48bd0b36499edc1bc91f6abb2a50
-    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
-    kubeVersion: '>= 1.19'
-    maintainers:
-    - email: marco@fire.ly
-      name: Marco Visser
-      url: https://fire.ly
-    name: firely-auth
-    type: application
-    urls:
-    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.3.0/firely-auth-0.3.0.tgz
-    version: 0.3.0
-  - apiVersion: v2
-    appVersion: 3.0.0
-    created: "2024-12-19T13:56:40.627472565Z"
-    description: A Helm chart for Kubernetes, deploying the Firely Auth Server
-    digest: afc099066f698622a887666de74fe96de12a39bc164e73b2e81edbbbfd3d5bd8
-    icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
-    kubeVersion: '>= 1.19'
-    maintainers:
-    - email: marco@fire.ly
-      name: Marco Visser
-      url: https://fire.ly
-    name: firely-auth
-    type: application
-    urls:
-    - https://github.com/FirelyTeam/Helm.Charts/releases/download/FA%2Fv0.2.0/firely-auth-0.2.0.tgz
-    version: 0.2.0
-generated: "2025-02-10T10:02:46.701398166Z"
+generated: "2025-09-02T10:12:51.814296819Z"


### PR DESCRIPTION
This PR updates the Helm Chart index.yaml to the latest release firely-server-0.20.1.