### PR TITLE
Using latest version for Firely Auth and Firely Server

### DIFF
--- a/charts/firely-auth/Chart.yaml
+++ b/charts/firely-auth/Chart.yaml
@@ -22,10 +22,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.3.0"
+appVersion: "4.4.0"

--- a/charts/firely-server/Chart.yaml
+++ b/charts/firely-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "6.1.0"
-version: "0.20.1"
+appVersion: "6.4.0"
+version: "0.21.0"
 kubeVersion: ">= 1.19.0-0"
 name: firely-server
 description: Firely Server is an enterprise-grade FHIR server meant for production environments large and small alike. 


### PR DESCRIPTION

## Description
Bumping app version and version so as to use the latest versions of Firely Auth and Firely Server by default

## Related issues

## Testing
Tested by deploying the helm charts
