### PR TITLE
removed double quotes for chart version

### DIFF
--- a/charts/firely-auth/Chart.yaml
+++ b/charts/firely-auth/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for Kubernetes, deploying the Firely Auth Server
 kubeVersion: ">= 1.19.0-0"
 icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
 maintainers:
-  - name: Louis Latour
-    email: louis@fire.ly
+  - name: Marten Smits
+    email: marten@fire.ly
     url: https://fire.ly
 
 

--- a/charts/firely-server/Chart.yaml
+++ b/charts/firely-server/Chart.yaml
@@ -7,8 +7,8 @@ description: Firely Server is an enterprise-grade FHIR server meant for producti
 home: https://fire.ly/products/firely-server/
 icon: https://fire.ly/wp-content/uploads/2021/09/ICONS_FIRELY_02-04.svg
 maintainers:
-  - name: Louis Latour
-    email: louis@fire.ly
+  - name: Marten Smits
+    email: marten@fire.ly
     url: https://fire.ly
 type: application
 

--- a/charts/firely-server/Chart.yaml
+++ b/charts/firely-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "6.4.0"
-version: "0.21.0"
+version: 0.21.0
 kubeVersion: ">= 1.19.0-0"
 name: firely-server
 description: Firely Server is an enterprise-grade FHIR server meant for production environments large and small alike. 


### PR DESCRIPTION
## Description
removed double quotes for firely server chart version

## Related issues
A standard Chart.yaml version value is without double quotes.
