### PR TITLE
Feature/devops 131 add pdb to helm chart

### DIFF
--- a/charts/.gitignore
+++ b/charts/.gitignore
@@ -1,2 +1,3 @@
 **/Chart.lock
 **/*.tgz
+*.DS_Store

--- a/charts/firely-auth/Chart.yaml
+++ b/charts/firely-auth/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/firely-auth/README.md
+++ b/charts/firely-auth/README.md
@@ -95,7 +95,7 @@ The following table lists the configurable parameters of the firely-auth chart a
 | `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage for the Horizontal Pod Autoscaler     | `80` |
 | `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage for the Horizontal Pod Autoscaler     | `80` |
 | `podDisruptionBudget.enabled`                           | Enable PodDisruptionBudget for Firely Auth                                 | `false` |
-| `podDisruptionBudget.minAvailable`                      | Minimum available pods allowed during a voluntary disruption               | `nil` |
+| `podDisruptionBudget.minAvailable`                      | Minimum available pods allowed during a voluntary disruption               | `1` |
 | `podDisruptionBudget.maxUnavailable`                    | Maximum unavailable pods allowed during a voluntary disruption             | `1` |
 | `podDisruptionBudget.labels`                            | Extra labels to add to the PodDisruptionBudget                             | `{}` |
 | `podDisruptionBudget.annotations`                       | Annotations to add to the PodDisruptionBudget                              | `{}` |

--- a/charts/firely-auth/README.md
+++ b/charts/firely-auth/README.md
@@ -94,6 +94,11 @@ The following table lists the configurable parameters of the firely-auth chart a
 | `autoscaling.maxReplicas`                               | Maximum number of replicas for the Horizontal Pod Autoscaler            | `5` |
 | `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage for the Horizontal Pod Autoscaler     | `80` |
 | `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage for the Horizontal Pod Autoscaler     | `80` |
+| `podDisruptionBudget.enabled`                           | Enable PodDisruptionBudget for Firely Auth                                 | `false` |
+| `podDisruptionBudget.minAvailable`                      | Minimum available pods allowed during a voluntary disruption               | `nil` |
+| `podDisruptionBudget.maxUnavailable`                    | Maximum unavailable pods allowed during a voluntary disruption             | `1` |
+| `podDisruptionBudget.labels`                            | Extra labels to add to the PodDisruptionBudget                             | `{}` |
+| `podDisruptionBudget.annotations`                       | Annotations to add to the PodDisruptionBudget                              | `{}` |
 
 Note that in order to use the Horizontal Pod Autoscaler, the Kubernetes cluster must have the [metrics server](https://github.com/kubernetes-sigs/metrics-server) installed and running.
 

--- a/charts/firely-auth/templates/poddisruptionbudget.yaml
+++ b/charts/firely-auth/templates/poddisruptionbudget.yaml
@@ -20,5 +20,7 @@ spec:
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- else if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  {{-   fail "podDisruptionBudget.enabled is true, but neither podDisruptionBudget.minAvailable nor podDisruptionBudget.maxUnavailable is set. Please configure one of them." }}
   {{- end }}
 {{- end }}

--- a/charts/firely-auth/templates/poddisruptionbudget.yaml
+++ b/charts/firely-auth/templates/poddisruptionbudget.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- if and (ne .Values.podDisruptionBudget.minAvailable nil) (ne .Values.podDisruptionBudget.maxUnavailable nil) }}
+{{-   fail "podDisruptionBudget.enabled is true, but both podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable are set. Please set exactly one of them." }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -16,9 +19,9 @@ spec:
   selector:
     matchLabels:
       {{- include "firely-auth.selectorLabels" . | nindent 6 }}
-  {{- if .Values.podDisruptionBudget.minAvailable }}
+  {{- if ne .Values.podDisruptionBudget.minAvailable nil }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else if ne .Values.podDisruptionBudget.maxUnavailable nil }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- else }}
   {{-   fail "podDisruptionBudget.enabled is true, but neither podDisruptionBudget.minAvailable nor podDisruptionBudget.maxUnavailable is set. Please configure one of them." }}

--- a/charts/firely-auth/templates/poddisruptionbudget.yaml
+++ b/charts/firely-auth/templates/poddisruptionbudget.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "firely-auth.fullname" . }}
+  labels:
+    {{- include "firely-auth.labels" . | nindent 4 }}
+    {{- with .Values.podDisruptionBudget.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podDisruptionBudget.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "firely-auth.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/firely-auth/values.yaml
+++ b/charts/firely-auth/values.yaml
@@ -164,7 +164,7 @@ podDisruptionBudget:
   enabled: false
   # Set exactly one of the following values; leave the other commented out
   minAvailable: 1
-  # maxUnavailable: 1 # Alternative to minAvailable; uncomment only if you comment out minAvailable
+  # maxUnavailable: 1  # Alternative to minAvailable; uncomment only if you comment out minAvailable
   labels: {}
   annotations: {}
 

--- a/charts/firely-auth/values.yaml
+++ b/charts/firely-auth/values.yaml
@@ -162,9 +162,9 @@ autoscaling:
 
 podDisruptionBudget:
   enabled: false
-  # Set exactly one of these
+  # Set exactly one of the following values; leave the other commented out
   minAvailable: 1
-  # maxUnavailable: 1
+  # maxUnavailable: 1 # Alternative to minAvailable; uncomment only if you comment out minAvailable
   labels: {}
   annotations: {}
 

--- a/charts/firely-auth/values.yaml
+++ b/charts/firely-auth/values.yaml
@@ -160,6 +160,14 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+podDisruptionBudget:
+  enabled: true
+  # Set exactly one of these
+  minAvailable: 1
+  # maxUnavailable: 1
+  labels: {}
+  annotations: {}
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/firely-auth/values.yaml
+++ b/charts/firely-auth/values.yaml
@@ -161,7 +161,7 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 
 podDisruptionBudget:
-  enabled: true
+  enabled: false
   # Set exactly one of these
   minAvailable: 1
   # maxUnavailable: 1

--- a/charts/firely-server/Chart.yaml
+++ b/charts/firely-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: "6.4.0"
-version: "0.21.0"
+version: 0.22.0
 kubeVersion: ">= 1.19.0-0"
 name: firely-server
 description: Firely Server is an enterprise-grade FHIR server meant for production environments large and small alike. 

--- a/charts/firely-server/README.md
+++ b/charts/firely-server/README.md
@@ -97,6 +97,11 @@ The following table lists the configurable parameters of the firely-server chart
 | `autoscaling.maxReplicas`                               | Maximum number of replicas for the Horizontal Pod Autoscaler            | `10` |
 | `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage for the Horizontal Pod Autoscaler     | `80` |
 | `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage for the Horizontal Pod Autoscaler     | `80` |
+| `podDisruptionBudget.enabled`                           | Enable PodDisruptionBudget for Firely Server                                 | `false` |
+| `podDisruptionBudget.minAvailable`                      | Minimum available pods allowed during a voluntary disruption               | `nil` |
+| `podDisruptionBudget.maxUnavailable`                    | Maximum unavailable pods allowed during a voluntary disruption             | `1` |
+| `podDisruptionBudget.labels`                            | Extra labels to add to the PodDisruptionBudget                             | `{}` |
+| `podDisruptionBudget.annotations`                       | Annotations to add to the PodDisruptionBudget                              | `{}` |
 
 Note that in order to use the Horizontal Pod Autoscaler, the Kubernetes cluster must have the [metrics server](https://github.com/kubernetes-sigs/metrics-server) installed and running.
 

--- a/charts/firely-server/README.md
+++ b/charts/firely-server/README.md
@@ -98,7 +98,7 @@ The following table lists the configurable parameters of the firely-server chart
 | `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage for the Horizontal Pod Autoscaler     | `80` |
 | `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage for the Horizontal Pod Autoscaler     | `80` |
 | `podDisruptionBudget.enabled`                           | Enable PodDisruptionBudget for Firely Server                                 | `false` |
-| `podDisruptionBudget.minAvailable`                      | Minimum available pods allowed during a voluntary disruption               | `nil` |
+| `podDisruptionBudget.minAvailable`                      | Minimum available pods allowed during a voluntary disruption               | `1` |
 | `podDisruptionBudget.maxUnavailable`                    | Maximum unavailable pods allowed during a voluntary disruption             | `1` |
 | `podDisruptionBudget.labels`                            | Extra labels to add to the PodDisruptionBudget                             | `{}` |
 | `podDisruptionBudget.annotations`                       | Annotations to add to the PodDisruptionBudget                              | `{}` |

--- a/charts/firely-server/README.md
+++ b/charts/firely-server/README.md
@@ -98,11 +98,12 @@ The following table lists the configurable parameters of the firely-server chart
 | `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage for the Horizontal Pod Autoscaler     | `80` |
 | `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage for the Horizontal Pod Autoscaler     | `80` |
 | `podDisruptionBudget.enabled`                           | Enable PodDisruptionBudget for Firely Server                                 | `false` |
-| `podDisruptionBudget.minAvailable`                      | Minimum available pods allowed during a voluntary disruption               | `1` |
-| `podDisruptionBudget.maxUnavailable`                    | Maximum unavailable pods allowed during a voluntary disruption             | `1` |
+| `podDisruptionBudget.minAvailable`                      | Minimum available pods allowed during a voluntary disruption (active default when PodDisruptionBudget is enabled) | `1` |
+| `podDisruptionBudget.maxUnavailable`                    | Maximum unavailable pods allowed during a voluntary disruption (no default; set in values.yaml instead of `minAvailable` if desired) | - |
 | `podDisruptionBudget.labels`                            | Extra labels to add to the PodDisruptionBudget                             | `{}` |
 | `podDisruptionBudget.annotations`                       | Annotations to add to the PodDisruptionBudget                              | `{}` |
 
+**Note:** Only one of `podDisruptionBudget.minAvailable` or `podDisruptionBudget.maxUnavailable` should be set. By default, only `minAvailable: 1` is active; `maxUnavailable` is commented out in `values.yaml` and has no default.
 Note that in order to use the Horizontal Pod Autoscaler, the Kubernetes cluster must have the [metrics server](https://github.com/kubernetes-sigs/metrics-server) installed and running.
 
 ### Traffic Exposure Parameters

--- a/charts/firely-server/templates/poddisruptionbudget.yaml
+++ b/charts/firely-server/templates/poddisruptionbudget.yaml
@@ -20,5 +20,7 @@ spec:
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- else if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  {{-   fail "podDisruptionBudget.enabled is true, but neither podDisruptionBudget.minAvailable nor podDisruptionBudget.maxUnavailable is set. Please configure one of them." }}
   {{- end }}
 {{- end }}

--- a/charts/firely-server/templates/poddisruptionbudget.yaml
+++ b/charts/firely-server/templates/poddisruptionbudget.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- if and (ne .Values.podDisruptionBudget.minAvailable nil) (ne .Values.podDisruptionBudget.maxUnavailable nil) }}
+{{-   fail "podDisruptionBudget.enabled is true, but both podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable are set. Please set exactly one of them." }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -16,9 +19,9 @@ spec:
   selector:
     matchLabels:
       {{- include "firely-server.selectorLabels" . | nindent 6 }}
-  {{- if .Values.podDisruptionBudget.minAvailable }}
+  {{- if ne .Values.podDisruptionBudget.minAvailable nil }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else if ne .Values.podDisruptionBudget.maxUnavailable nil }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- else }}
   {{-   fail "podDisruptionBudget.enabled is true, but neither podDisruptionBudget.minAvailable nor podDisruptionBudget.maxUnavailable is set. Please configure one of them." }}

--- a/charts/firely-server/templates/poddisruptionbudget.yaml
+++ b/charts/firely-server/templates/poddisruptionbudget.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "firely-server.fullname" . }}
+  labels:
+    {{- include "firely-server.labels" . | nindent 4 }}
+    {{- with .Values.podDisruptionBudget.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podDisruptionBudget.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "firely-server.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/firely-server/values.yaml
+++ b/charts/firely-server/values.yaml
@@ -157,6 +157,14 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+podDisruptionBudget:
+  enabled: false
+  # Set exactly one of these
+  minAvailable: 1
+  # maxUnavailable: 1
+  labels: {}
+  annotations: {}
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/firely-server/values.yaml
+++ b/charts/firely-server/values.yaml
@@ -159,9 +159,9 @@ autoscaling:
 
 podDisruptionBudget:
   enabled: false
-  # Set exactly one of these
+  # Set exactly one of the following values; leave the other commented out
   minAvailable: 1
-  # maxUnavailable: 1
+  # maxUnavailable: 1  # Alternative to minAvailable; uncomment only if you comment out minAvailable
   labels: {}
   annotations: {}
 


### PR DESCRIPTION
## Description
This PR adds PodDisruptionBudget (PDB) support to both the Firely Server and Firely Auth Helm charts to control pod disruptions during voluntary cluster operations like node drains and upgrades.

Key Changes:

Added PodDisruptionBudget template files for both charts with configurable minAvailable and maxUnavailable settings
Updated values.yaml files with PDB configuration (disabled by default for firely-server and firely-auth)
Documented the new PDB parameters in README files for both charts
Bumped chart versions (firely-server to 0.22.0, firely-auth to 0.10.0)

## Related issues
Closes|Fixes|Resolves [DEVOPS-131](https://firely.atlassian.net/browse/DEVOPS-131).

## Testing
This change was tested by deploying FS and FA using new helm chart and creating voluntary disruptions by draining node.

## FirelyTeam Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes

[DEVOPS-131]: https://firely.atlassian.net/browse/DEVOPS-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ